### PR TITLE
Fix npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "npm": "1.3.x"
   },
   "scripts": {
-    "start": "web.js"
+    "start": "node web.js"
   }
 }


### PR DESCRIPTION
It's good to have the scripts working in a `package.json` so when someone new goes to the project, they know how to start the app.
